### PR TITLE
remove assumption of `package.el` use

### DIFF
--- a/vega-view.el
+++ b/vega-view.el
@@ -30,9 +30,6 @@
 ;; vega-view is an Emacs Lisp library for visualizing Vega
 ;; spcifications.
 
-(unless (package-installed-p 'parseedn)
-  (package-install 'parseedn))
-
 (require 'cl-lib)
 (require 'parseedn)
 


### PR DESCRIPTION
I use `use-package` and the package manager `straight.el`, and for some reason in spite of already having the `parseedn` package installed, I was unable to install and use `emacs-vega-view` with this setup, because even calling `(package-installed-p 'parseedn)` fails:

```
Debugger entered--Lisp error: (error "package.el is not yet initialized!")
  signal(error ("package.el is not yet initialized!"))
  error("package.el is not yet initialized!")
  package-installed-p(parseedn)
  eval((package-installed-p (quote parseedn)) nil)
... elided for brevity
```

I am not sure why (package-installed-p) fails, but I wonder if it's a good idea for `emacs-vega-view` to have this code which seems to expect that the user is using `package.el`. Perhaps the installation instructions should state that it depends on `parseedn` instead?

Here is a (working, with the change in this PR) snippet of my clojure emacs config file with `use-package` and `straight.el`

```elisp
(use-package parseedn
  :demand t
  :straight
  (parseedn :type git
            :host github
            :repo "clojure-emacs/parseedn"
            :branch "master"))

(use-package vega-view
  :demand t
  :straight
  (vega-view :type git :host github :repo "blak3mill3r/emacs-vega-view" :branch "master"))

```