### PR TITLE
Use `cider-last-sexp` to get sexp string in Clojure mode

### DIFF
--- a/vega-view.el
+++ b/vega-view.el
@@ -146,7 +146,7 @@ resulting SVG in the `*vega*` buffer."
                                      (mapcar #'car supported-modes))))))
     (let ((sexp-string (if (or (eq major-mode 'clojure-mode)
                                (eq major-mode 'cider-repl-mode))
-                           (cider-sexp-at-point)
+                           (cider-last-sexp)
                          (thing-at-point 'sexp 'no-props))))
       (cl-assert (and (stringp sexp-string) (> (length sexp-string) 0))
                  nil


### PR DESCRIPTION
Not sure if this was considered already, if so feel free to ignore this PR :)

The main benefit of using `cider-last-sexp` instead of `cider-sexp-at-point` is that the former is able to recognize Clojure data structures (maps) that are not necessarily top-most forms, while the latter can't.  This is useful for when you're wrapping your vega map declarations inside `comment` blocks.

For example, consider:

```clj
(comment
  {:foo :bar}|
  )
```

(pointer at `|`)

`cider-sexp-at-point` returns `nil`.
`cider-last-sexp` returns `"{:foo :bar}"`.

`cider-last-sexp` is also the function used by the command `cider-eval-last-sexp`, so using it inside `vega-view` might feel more familiar: you can run `vega-view` any place where you would normally `C-x C-e` to eval an expression.