### PR TITLE
Add clojurec-mode, clojurescript-mode support

### DIFF
--- a/vega-view.el
+++ b/vega-view.el
@@ -136,6 +136,8 @@ resulting SVG in the `*vega*` buffer."
   (interactive)
   (let* ((supported-modes '((cider-repl-mode vega-view--clojure)
                             (clojure-mode vega-view--clojure)
+                            (clojurec-mode vega-view--clojure)
+                            (clojurescript-mode vega-view--clojure)
                             (emacs-lisp-mode vega-view--elisp)
                             (lisp-interaction-mode vega-view--elisp)
                             (json-mode vega-view--json)


### PR DESCRIPTION
I'm writing up a guide for how to use sicmutils with various editors, and this came up!

Now if only we can get Cider to do this for us... https://github.com/clojure-emacs/cider/pull/2248/files