### PR TITLE
Fix mark type on Readme's clojure example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ plot twenty random values as a line chart:
                      (range 1 20)
                      (repeat :b)
                      (repeatedly #(* 100 (Math/random))))}
-   :mark "bar",
+   :mark "line",
    :width 800
    :height 600
    :encoding {:x {:field :a, :type "ordinal", :axis {"labelAngle" 0}},


### PR DESCRIPTION
It _gently_ threw me off (an absolute Vega beginner)

Thanks for writing this!